### PR TITLE
Small change so that Max Degrees Per Letter to consider multiline text

### DIFF
--- a/CurvedTextMeshPro/Assets/CurvedTextMeshPro/Scripts/TextProOnACircle.cs
+++ b/CurvedTextMeshPro/Assets/CurvedTextMeshPro/Scripts/TextProOnACircle.cs
@@ -113,7 +113,7 @@ namespace ntw.CurvedTextMeshPro
         protected override Matrix4x4 ComputeTransformationMatrix(Vector3 charMidBaselinePos, float zeroToOnePos, TMP_TextInfo textInfo, int charIdx)      
         {
             //calculate the actual degrees of the arc considering the maximum distance between letters
-            float actualArcDegrees = Mathf.Min(m_arcDegrees, textInfo.characterCount * m_maxDegreesPerLetter);
+            float actualArcDegrees = Mathf.Min(m_arcDegrees, textInfo.characterCount / textInfo.lineCount * m_maxDegreesPerLetter);
 
             //compute the angle at which to show this character.
             //We want the string to be centered at the top point of the circle, so we first convert the position from a range [0, 1]


### PR DESCRIPTION
Thanks so much for this script.  It was exactly what I needed.

I made a small change I wanted to contribute back.  The Max Degrees Per Letter setting is nice, but I noticed that it kept expanding even though text had wrapped to the next line which looked bad.  This small change just makes it divide by the number of lines so that the distance between characters stays more consistent between single and multi line text.